### PR TITLE
replaced preparsescript.sh with a matlab function (preparsescript.m) …

### DIFF
--- a/matlab/preparsescript.m
+++ b/matlab/preparsescript.m
@@ -1,0 +1,18 @@
+function preparsescript(srcFullFileName, dstFullFileName)
+
+fin = fopen(srcFullFileName,'r');
+[~,~,machinefmt,encoding] = fopen(fin);
+cont = fread(fin,Inf,'*char')';
+fclose(fin);
+
+cont = regexprep(cont,'cim:','');
+cont = regexprep(cont,'rdf:ID','ID');
+cont = regexprep(cont,'rdf:resource=\"([#]?)','rdf_resource=\"');
+cont = regexprep(cont,'<([A-Za-z]*)\.([A-Za-z]*)>(.*)</([A-Za-z]*)\.([A-Za-z]*)>','<$1_$2>$3<\/$4_$5>','dotexceptnewline');
+cont = regexprep(cont,'<([A-Za-z]*)\.([A-Za-z]*) ', '<$1_$2\ ','dotexceptnewline');
+
+fout = fopen(dstFullFileName,'w',machinefmt,encoding);
+fwrite(fout,cont,'char');
+fclose(fout);
+
+

--- a/matlab/preparsescript.sh
+++ b/matlab/preparsescript.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-# makes the cim model MATLAB "readable"
-cat $1 | sed 's/cim://g' | sed 's/rdf:ID/ID/g' | sed -E 's/rdf:resource=\"([#]?)/rdf_resource=\"/g' | sed -E 's/<([A-Za-z]*)\.([A-Za-z]*)>(.*)<\/([A-Za-z]*)\.([A-Za-z]*)>/<\1_\2>\3<\/\4_\5>/g' | sed -E 's/<([A-Za-z]*)\.([A-Za-z]*) /<\1_\2\ /g' > $2


### PR DESCRIPTION
Since I work on a Windows computer, I could not execute the shell-script to pre-parse the *cim-files without further ado. I wrote a Matlab function that prepares the *cim files. This makes the transform.m function platform-independent. 

I also reworked the handling of the Simulink model. - I use new_system instead of "open".